### PR TITLE
new syntax for ShieldSymbolizer

### DIFF
--- a/reference.json
+++ b/reference.json
@@ -316,6 +316,7 @@
                 "css": "shield-name",
                 "type": "string",
                 "required": true,
+                "serialization": "content",
                 "doc": "Value to use for a shield\"s text label. Data columns are specified using brackets like [column_name]"
             },
             "face-name": {


### PR DESCRIPTION
the new syntax for the ShieldSymbolizer was missing

```
<ShieldSymbolizer>[label]</TextSymbolizer>
```
