### PR TITLE
Make 'point-file' property optional. Closes #27.

### DIFF
--- a/2.0.1/reference.json
+++ b/2.0.1/reference.json
@@ -566,7 +566,7 @@
             "file": {
                 "css": "point-file",
                 "type": "uri",
-                "required": true,
+                "required": false,
                 "default-value": "none",
                 "doc": "Image file to represent a point"
             },

--- a/2.1.0/reference.json
+++ b/2.1.0/reference.json
@@ -1086,7 +1086,7 @@
             "file": {
                 "css": "point-file",
                 "type": "uri",
-                "required": true,
+                "required": false,
                 "default-value": "none",
                 "doc": "Image file to represent a point"
             },

--- a/latest/reference.json
+++ b/latest/reference.json
@@ -1086,7 +1086,7 @@
             "file": {
                 "css": "point-file",
                 "type": "uri",
-                "required": true,
+                "required": false,
                 "default-value": "none",
                 "doc": "Image file to represent a point"
             },


### PR DESCRIPTION
Changes all of 2.0, 2.1 and "latest" references. I dunno if this is the correct way to do this or the files are generated, anyway this change fixes my use case in https://github.com/mapbox/carto/issues/167
