### PR TITLE
Typo in marker section: height -> width

### DIFF
--- a/2.0.1/reference.json
+++ b/2.0.1/reference.json
@@ -259,7 +259,7 @@
             "width": {
                 "css": "marker-width",
                 "default-value": 10,
-                "doc": "The height of the marker, if using one of the default types.",
+                "doc": "The width of the marker, if using one of the default types.",
                 "type": "float"
             },
             "height": {

--- a/2.0.2/reference.json
+++ b/2.0.2/reference.json
@@ -259,7 +259,7 @@
             "width": {
                 "css": "marker-width",
                 "default-value": 10,
-                "doc": "The height of the marker, if using one of the default types.",
+                "doc": "The width of the marker, if using one of the default types.",
                 "type": "float"
             },
             "height": {

--- a/2.1.0/reference.json
+++ b/2.1.0/reference.json
@@ -471,7 +471,7 @@
             "width": {
                 "css": "marker-width",
                 "default-value": 10,
-                "doc": "The height of the marker, if using one of the default types.",
+                "doc": "The width of the marker, if using one of the default types.",
                 "type": "expression"
             },
             "height": {


### PR DESCRIPTION
Probably also affects http://mapbox.com/carto/2.1.0.html#section-markers
