### PR TITLE
Add list placement to text and shield symbolizers from 2.1.0 onwards.

### DIFF
--- a/2.1.0/reference.json
+++ b/2.1.0/reference.json
@@ -1546,7 +1546,8 @@
                 "doc": "Re-position and/or re-size text to avoid overlaps. \"simple\" for basic algorithm (using text-placements string,) \"dummy\" to turn this feature off.",
                 "type": [
                     "dummy",
-                    "simple"
+                    "simple",
+                    "list"
                 ],
                 "default-value": "dummy"
             },

--- a/2.1.1/reference.json
+++ b/2.1.1/reference.json
@@ -1557,7 +1557,8 @@
                 "doc": "Re-position and/or re-size text to avoid overlaps. \"simple\" for basic algorithm (using text-placements string,) \"dummy\" to turn this feature off.",
                 "type": [
                     "dummy",
-                    "simple"
+                    "simple",
+                    "list"
                 ],
                 "default-value": "dummy"
             },

--- a/latest/reference.json
+++ b/latest/reference.json
@@ -980,7 +980,8 @@
                 "doc": "Re-position and/or re-size shield to avoid overlaps. \"simple\" for basic algorithm (using shield-placements string,) \"dummy\" to turn this feature off.",
                 "type": [
                     "dummy",
-                    "simple"
+                    "simple",
+                    "list"
                 ],
                 "default-value": "dummy"
             },
@@ -1691,7 +1692,8 @@
                 "doc": "Re-position and/or re-size text to avoid overlaps. \"simple\" for basic algorithm (using text-placements string,) \"dummy\" to turn this feature off.",
                 "type": [
                     "dummy",
-                    "simple"
+                    "simple",
+                    "list"
                 ],
                 "default-value": "dummy"
             },


### PR DESCRIPTION
There's still the outstanding problem of how to describe the different placements, but since this enables advanced users to use a workaround, it's still useful. At the very least, this documents what these advanced users need to edit to get things working!

References (but doesn't fully fix) https://github.com/mapnik/mapnik-reference/issues/45

Enables a CartoCSS workaround - see
 https://github.com/mapbox/carto/issues/238#issuecomment-19673987
