### PR TITLE
Fixes for colorize-alpha in 2.2.0

### DIFF
--- a/2.2.0/reference.json
+++ b/2.2.0/reference.json
@@ -26,9 +26,7 @@
                 ["y-gradient", 0],
                 ["invert", 0],
                 ["sharpen", 0],
-                ["colorize-alpha", -1],
-                ["color-to-alpha", 1],
-                ["scale-hsla", 8]
+                ["colorize-alpha", -1]
             ],
             "doc": "A list of image filters that will be applied to the active rendering canvas for a given style. The presence of one more more `image-filters` will trigger a new canvas to be created before starting to render a style and then this canvas will be composited back into the main canvas after rendering all features and after all `image-filters` have been applied. See `direct-image-filters` if you want to apply a filter directly to the main canvas."
         },


### PR DESCRIPTION
`colorize-alpha` was present in 2.2.0 but was accidentally removed (from most occurrences) in 97fed08ef5aed29fc82620bddd578da5389e4ee5 

Also, in one case the filter list wasn't trimmed, so the second commit does this.

These commits
- re-add `colorize-alpha` throughout
- remove `scale-hsla` and `color-to-alpha` from `style: image-filters`
