### PR TITLE
Support Layout and Format nodes in text and shield symbolizers

### DIFF
--- a/latest/reference.json
+++ b/latest/reference.json
@@ -905,6 +905,10 @@
             }
         },
         "shield": {
+            "child-elements": [
+                "format",
+                "layout"
+            ],
             "name": {
                 "css": "shield-name",
                 "type": "expression",
@@ -1634,6 +1638,10 @@
             }
         },
         "text": {
+            "child-elements": [
+                "format",
+                "layout"
+            ],
             "name": {
                 "css": "text-name",
                 "type": "expression",
@@ -1946,6 +1954,162 @@
             }
         }
 
+    },
+    "elements": {
+        "format": {
+            "child-elements": [
+                "format",
+                "layout"
+            ],
+            "pseudo": {
+                "before": {
+                    "behavior": "prepend",
+                    "indexed": true
+                },
+                "after": {
+                    "behavior": "append",
+                    "indexed": true
+                }
+            },
+            "content": {
+                "css": "content",
+                "type": "expression",
+                "default-value": "",
+                "serialization": "content",
+                "doc": "Value to use for a text label. Data columns are specified using brackets like [column_name]"
+            },
+            "face-name": {
+                "css": "face-name",
+                "type": "string",
+                "validate": "font",
+                "doc": "Font name and style to render a label in"
+            },
+            "size": {
+                "css": "size",
+                "type": "float",
+                "doc": "Text size in pixels"
+            },
+            "fill": {
+                "css": "fill",
+                "doc": "Specifies the color for the text",
+                "type": "color"
+            },
+            "halo-fill": {
+                "css": "halo-fill",
+                "type": "color",
+                "doc": "Specifies the color of the halo around the text."
+            },
+            "halo-radius": {
+                "css": "halo-radius",
+                "doc": "Specify the radius of the halo in pixels",
+                "type": "float"
+            },
+            "character-spacing": {
+                "css": "character-spacing",
+                "type": "float",
+                "doc": "Horizontal spacing adjustment between characters in pixels"
+            },
+            "line-spacing": {
+                "css": "line-spacing",
+                "type": "unsigned",
+                "doc": "Vertical spacing adjustment between lines in pixels"
+            },
+            "wrap-character": {
+                "css": "wrap-character",
+                "type": "string",
+                "doc": "Use this character instead of a space to wrap long text."
+            },
+            "text-transform": {
+                "css": "transform",
+                "type": [
+                    "none",
+                    "uppercase",
+                    "lowercase",
+                    "capitalize"
+                ],
+                "doc": "Transform the case of the characters"
+            }
+        },
+        "layout": {
+            "child-elements": [
+                "format",
+                "layout"
+            ],
+            "pseudo": {
+                "layout": {
+                    "indexed": true,
+                    "behavior": "append"
+                }
+            },
+            "content": {
+                "css": "content",
+                "type": "expression",
+                "default-value": "",
+                "serialization": "content",
+                "doc": "Value to use for a text label. Data columns are specified using brackets like [column_name]"
+            },
+            "dx": {
+                "css": "dx",
+                "type": "float",
+                "doc": "Displace text by fixed amount, in pixels, +/- along the X axis.  With \"dummy\" placement-type, a positive value displaces to the right. With \"simple\" placement-type, it is either left, right or unchanged, depending on the placement selected. Any non-zero value implies \"horizontal-alignment\" changes to \"left\" by default. Has no effect with 'line' text-placement-type."
+            },
+            "dy": {
+                "css": "dy",
+                "type": "float",
+                "doc": "Displace text by fixed amount, in pixels, +/- along the Y axis.  With \"dummy\" placement-type, a positive value displaces downwards. With \"simple\" placement-type, it is either up, down or unchanged, depending on the placement selected. With \"line\" placement-type, a positive value displaces below the path."
+            },
+            "vertical-alignment": {
+                "css": "vertical-alignment",
+                "type": [
+                  "top",
+                  "middle",
+                  "bottom",
+                  "auto"
+                ],
+                "doc": "Position of label relative to point position."
+            },
+            "horizontal-alignment": {
+                "css": "horizontal-alignment",
+                "type": [
+                    "left",
+                    "middle",
+                    "right",
+                    "auto"
+                ],
+                "doc": "The text's horizontal alignment from its centerpoint"
+            },
+            "justify-alignment": {
+                "css": "align",
+                "type": [
+                    "left",
+                    "right",
+                    "center",
+                    "auto"
+                ],
+                "doc": "Define how text is justified"
+            },
+            "text-ratio": {
+                "css": "text-ratio",
+                "doc": "Define the amount of text (of the total) present on successive lines when wrapping occurs",
+                "type": "unsigned"
+            },
+            "wrap-width": {
+                "css": "wrap-width",
+                "doc": "Length of a chunk of text in characters before wrapping text",
+                "default-value": 0,
+                "type": "unsigned"
+            },
+            "wrap-before": {
+                "css": "wrap-before",
+                "type": "boolean",
+                "doc": "Wrap text before wrap-width is reached. If false, wrapped lines will be a bit longer than wrap-width."
+            },
+            "orientation": {
+                "css": "orientation",
+                "type": "expression",
+                "doc": "Rotate the text."
+            }
+        }
     },
     "colors": {
         "aliceblue":  [240, 248, 255],

--- a/test/lint.js
+++ b/test/lint.js
@@ -14,6 +14,7 @@ var lint_ref = function(ver) {
     for (var symbolizer in symbolizers) {
         if (symbolizer === 'colors') continue;
         for (var prop in symbolizers[symbolizer]) {
+            if (prop === 'child-elements') continue;
             if (!symbolizers[symbolizer][prop].doc) {
                 if (symbolizer !== cursim) {
                     cursim = symbolizer;
@@ -35,6 +36,7 @@ var lint_ref = function(ver) {
     for (var symbolizer in symbolizers) {
         if (symbolizer === 'colors') continue;
         for (var prop in symbolizers[symbolizer]) {
+            if (prop === 'child-elements') continue;
             if (symbolizers[symbolizer][prop]['default-value'] === undefined) {
                 if (symbolizer !== cursim) {
                     cursim = symbolizer;

--- a/test/test.py
+++ b/test/test.py
@@ -7,6 +7,20 @@ except ImportError:
     # >= python 2.6
     import json
 
+def testAttribute(parent, attr):
+    assert 'type' in attr[1].keys(), '%s: type not in %s' % (parent[0], attr[0])
+    #assert 'doc' in attr[1].keys(), '%s: doc string not in %s' % (parent[0], attr[0])
+    assert 'css' in attr[1].keys(), '%s: css not in %s' % (parent[0], attr[0])
+
+def testPsuedo(parent, attr):
+    for i in attr[1].items():
+        assert 'behavior' in i[1].keys(), '%s: behavior not in %s' % (parent[0], i[0])
+        assert 'indexed' in i[1].keys(), '%s: indexed not in %s' % (parent[0], i[0])
+
+def testChildElements(parent, attr, reference):
+    for child in attr[1]:
+        assert child in reference['elements'].keys(), '%s: %s is not a valid element' % (parent[0], child)
+
 versions = ['2.0.0','2.0.1', '2.0.2', '2.1.0', '2.1.1', '2.3.0', 'latest']
 
 for v in versions:
@@ -17,12 +31,23 @@ for v in versions:
     for sym in reference['symbolizers'].items():
         assert sym[1]
         for i in sym[1].items():
-            if sym[0] not in ['map','*']:
-                group_name = sym[0]
-                if group_name == 'markers':
-                    group_name = 'marker'
-                css_name = i[1]['css']
-                assert group_name in css_name, "'%s' not properly prefixed by '%s'" % (css_name,group_name)
-            assert 'type' in i[1].keys(), '%s: type not in %s' % (sym[0], i[0])
-            assert 'doc' in i[1].keys(), '%s: doc string not in %s' % (sym[0], i[0])
-            assert 'css' in i[1].keys(), '%s: css not in %s' % (sym[0], i[0])
+            if i[0] == 'child-elements':
+                testChildElements(sym, i, reference)
+            else:
+                testAttribute(sym, i)
+                if sym[0] not in ['map','*']:
+                    group_name = sym[0]
+                    if group_name == 'markers':
+                        group_name = 'marker'
+                    css_name = i[1]['css']
+                    assert group_name in css_name, "'%s' not properly prefixed by '%s'" % (css_name,group_name)
+    if 'elements' in reference.keys():
+        for elem in reference['elements'].items():
+            assert elem[1]
+            for i in elem[1].items():
+                if i[0] == 'child-elements':
+                    testChildElements(elem, i, reference)
+                elif i[0] == 'pseudo':
+                    testPsuedo(elem, i)
+                else:
+                    testAttribute(elem, i)


### PR DESCRIPTION
This is a potential addition, which corresponds with mapbox/carto#358. The goal is to support definition of layout and format nodes in carto, as discussed in mapbox/carto#347.

What is being added here is child element types (currently layout and format), along with their attributes, that can be defined inside of text and shield symbolizers in mapnik XML. Also added are css pseudo-elements that can be used to create and define these elements in carto. In mapnik, format and layout elements can be contained within text and shield symbolizers, and they can also be nested inside of each other. The child-elements lists are used to control which types of elements can go where.

Along with the proposed changes to carto compiler (mapbox/carto#358), this is designed to allow for expansion to other xml tags that can be defined inside of a symbolizer. In particular, a 'placement' element type could easily be added to define alternate placements for list placement mode (see #45 and mapbox/carto#238).
