### PR TITLE
fix text-dy doc

### DIFF
--- a/2.3.0/reference.json
+++ b/2.3.0/reference.json
@@ -1771,7 +1771,7 @@
             "dy": {
                 "css": "text-dy",
                 "type": "float",
-                "doc": "Displace text by fixed amount, in pixels, +/- along the Y axis.  A positive value will shift the text down.",
+                "doc": "Displace text by fixed amount, in pixels, +/- along the Y axis.  A positive value will shift the text up.",
                 "default-value": 0
             },
             "vertical-alignment": {
@@ -1784,7 +1784,7 @@
                 ],
                 "doc": "Position of label relative to point position.",
                 "default-value": "auto",
-                "default-meaning": "Default affected by value of dy; \"bottom\" for dy>0, \"top\" for dy<0."
+                "default-meaning": "Default affected by value of dy; \"top\" for dy>0, \"bottom\" for dy<0."
             },
             "avoid-edges": {
                 "css": "text-avoid-edges",

--- a/3.0.0/reference.json
+++ b/3.0.0/reference.json
@@ -2155,7 +2155,7 @@
                 "css": "text-dy",
                 "type": "float",
                 "expression":true,
-                "doc": "Displace text by fixed amount, in pixels, +/- along the Y axis.  With \"dummy\" placement-type, a positive value displaces downwards. With \"simple\" placement-type, it is either up, down or unchanged, depending on the placement selected. With \"line\" placement-type, a positive value displaces below the path.",
+                "doc": "Displace text by fixed amount, in pixels, +/- along the Y axis.  With \"dummy\" placement-type, a positive value displaces downwards. With \"simple\" placement-type, it is either up, down or unchanged, depending on the placement selected. With \"line\" placement-type, a positive value displaces above the path.",
                 "default-meaning": "Text will not be displaced.",
                 "default-value": 0
             },
@@ -2170,7 +2170,7 @@
                 "expression":true,
                 "doc": "Position of label relative to point position.",
                 "default-value": "auto",
-                "default-meaning": "Default affected by value of dy; \"bottom\" for dy>0, \"top\" for dy<0."
+                "default-meaning": "Default affected by value of dy; \"top\" for dy>0, \"bottom\" for dy<0."
             },
             "avoid-edges": {
                 "css": "text-avoid-edges",


### PR DESCRIPTION
The logich was literally upside down.

See dy in 3.x from this pull request I just made:
https://github.com/mapnik/mapnik/pull/2445

dy in 2.3.x (vertical-alignment=top has no effect here, can be ignored):
https://github.com/mapnik/mapnik/blob/2.3.x/tests/visual_tests/images/charspacing-lines-300-300-1.0-agg-reference.png
https://github.com/mapnik/mapnik/blob/2.3.x/tests/visual_tests/styles/charspacing-lines.xml
