### PR TITLE
Add text-upright

### DIFF
--- a/3.0.0/reference.json
+++ b/3.0.0/reference.json
@@ -2234,8 +2234,22 @@
                 "type": "float",
                 "expression":true,
                 "default-value": 0,
-                "doc": "Rotate the text.",
+                "doc": "Rotate the text. (only works with text-placement:point).",
                 "default-meaning": "Text is not rotated and is displayed upright."
+            },
+            "upright": {
+                "css": "text-upright",
+                "default-value": "auto",
+                "type": [
+                    "auto",
+                    "left",
+                    "right",
+                    "left_only",
+                    "right_only"
+                ],
+                "expression":true,
+                "default-meaning": "Text will be positioned upright automatically.",
+                "doc": "How this label should be placed along lines. By default when more than half of a labels characters are upside down the label is automatically flipped to keep it upright. By changing this parameter you can prevent this \"auto-upright\" behavior. The \"left\" or \"right\" settings can be used to force text to always be placed along a line in a given direction and therefore disables flipping if text appears upside down. The \"left_only\" or \"right_only\" properties also force a given direction but will discard upside down text rather than trying to flip it."
             },
             "placement": {
                 "css": "text-placement",


### PR DESCRIPTION
This has been in Mapnik 3.x for a while but missed being added to the ref.