### PR TITLE
Lazy load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## CHANGELOG
 
+### 7.0.0
+
+* Changed API to lazily load each reference (helps avoid `require` performance cost).
+
+Changes are:
+
+ - Removed `mapnik-reference.version` object
+ - Added `mapnik-reference.versions` array
+ - Added `mapnik-reference.load()` function. Accepts ref version string, returns the reference instance
+
 ### 6.0.5
 
 * Added `dots` symbolizer

--- a/README.md
+++ b/README.md
@@ -31,12 +31,27 @@ This is a valid [npm](http://npmjs.org/) module and therefore can easily be used
 
     npm install mapnik-reference
 
-Once installing it as a dependency (like it's used in Carto), it can be included
-and used for a specific version of Mapnik:
+Install it as a dependency of your application. Then use that API to get a reference instance
+for a specific version of Mapnik:
 
 ```javascript
 var mapnik_reference = require('mapnik-reference');
-var data = mapnik_reference.version['2.1.0'];
+var ref = mapnik_reference.load('3.0.0');
+```
+
+You can also get access to an array of all known versions:
+
+```javascript
+var mapnik_reference = require('mapnik-reference');
+mapnik_reference.versions;
+[ '2.0.0',
+  '2.0.1',
+  '2.0.2',
+  '2.1.0',
+  '2.1.1',
+  '2.2.0',
+  '2.3.0',
+  '3.0.0' ]
 ```
 
 Other implementations will want to simply copy the [JSON](http://www.json.org/) file

--- a/index.js
+++ b/index.js
@@ -2,10 +2,7 @@ var fs = require('fs'),
     path = require('path'),
     existsSync = require('fs').existsSync || require('path').existsSync;
 
-// Load all stated versions into the module exports
-module.exports.version = {};
-
-var refs = [
+var versions = [
  '2.0.0',
  '2.0.1',
  '2.0.2',
@@ -16,10 +13,16 @@ var refs = [
  '3.0.0'
 ];
 
-refs.map(function(version) {
-    module.exports.version[version] = require(path.join(__dirname, version, 'reference.json'));
+module.exports.versions = versions;
+
+module.exports.load = function(version) {
+    if (versions.indexOf(version) <= -1) {
+        throw new Error("Unknown mapnik-reference version: '" + version + "'");
+    }
+    var ref = require(path.join(__dirname, version, 'reference.json'));
     var ds_path = path.join(__dirname, version, 'datasources.json');
     if (existsSync(ds_path)) {
-        module.exports.version[version].datasources = require(ds_path).datasources;
+        ref.datasources = require(ds_path).datasources;
     }
-});
+    return ref;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,11 +1,11 @@
 var assert = require('assert');
-var references = require('../');
+var mapnikref = require('../');
 var glob = require('glob');
 var path = require('path');
 
 describe('datasources', function() {
-    for (var key in references.version) {
-        var spec = references.version[key];
+    mapnikref.versions.forEach(function(key) {
+        var spec = mapnikref.load(key);
         if (spec.datasources) {
             it('show provide metadata for '+key, function() {
                 var ds_spec = spec.datasources['postgis'];
@@ -15,21 +15,21 @@ describe('datasources', function() {
         } else {
             it.skip('show provide metadata for '+key, function() {});
         }
-    }
+    });
 });
 
 describe('styles', function() {
-    for (var key in references.version) {
+    mapnikref.versions.forEach(function(key) {
         (function(key) {
-            it('show report correct version for '+key, function() {
-                assert.equal(references.version[key].version,key);
+            it('report correct version for '+key, function() {
+                assert.equal(mapnikref.load(key).version,key);
             });
         })(key)
-    }
+    })
 
-    it('show reveal new property in Mapnik 2.3.0', function() {
-        assert.ok(references.version['2.3.0'].symbolizers.markers['geometry-transform']);
-        assert.ok(!references.version['2.0.0'].symbolizers.markers['geometry-transform']);
+    it('reveal new property in Mapnik 2.3.0', function() {
+        assert.ok(mapnikref.load('2.3.0').symbolizers.markers['geometry-transform']);
+        assert.ok(!mapnikref.load('2.0.0').symbolizers.markers['geometry-transform']);
     });
 });
 
@@ -37,9 +37,8 @@ describe('styles', function() {
 describe('versions', function() {
     it('show report all versions', function() {
         var versions = glob.sync("./*.*.*");
-        var versions2 = Object.keys(references.version);
         versions = versions.map(function(e) { return path.basename(e) })
-        assert.deepEqual(versions,versions2);
+        assert.deepEqual(versions,mapnikref.versions);
     });
 });
 


### PR DESCRIPTION
Adds an API to dynamically load a given reference instance by version:

```
var mapnik_reference = require('mapnik-reference');
mapnik_reference.load('3.0.0')
```

Old method of pre-initializing all versions is dropped to stem the growing performance hit of `require('mapnik-reference')`.