### PR TITLE
Add rotate-displacement option for TextSymbolizer in mapnik 3.0 reference

### DIFF
--- a/3.0.0/reference.json
+++ b/3.0.0/reference.json
@@ -2238,6 +2238,13 @@
                 "doc": "Rotate the text. (only works with text-placement:point).",
                 "default-meaning": "Text is not rotated and is displayed upright."
             },
+            "rotate-displacement": {
+                "css": "text-rotate-displacement",
+                "type": "boolean",
+                "doc": "Rotates the displacement around the placement origin by the angle given by \"orientation\".",
+                "default-value": false,
+                "default-meaning": ""
+            },
             "upright": {
                 "css": "text-upright",
                 "default-value": "auto",

--- a/3.0.0/reference.json
+++ b/3.0.0/reference.json
@@ -2243,7 +2243,7 @@
                 "type": "boolean",
                 "doc": "Rotates the displacement around the placement origin by the angle given by \"orientation\".",
                 "default-value": false,
-                "default-meaning": ""
+                "default-meaning": "Label center is used for rotation."
             },
             "upright": {
                 "css": "text-upright",


### PR DESCRIPTION
As described in https://github.com/mapnik/mapnik/wiki/TextSymbolizer, fix for issue #87. 