### PR TITLE
Use semver to define which version to load (fix #108)

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,8 @@ var fs = require('fs'),
 
 
 var getVersions = function () {
-    var names = fs.readdirSync('./'), versions = [];
-    for (var i = 0; i < names.length; i++) {
-        if(names[i].match(/^\d{1,2}\.\d{1,2}\.\d{1,2}$/)) versions.push(names[i]);
-    };
-    return versions;
+    var names = fs.readdirSync('./');
+    return names.filter(semver.valid);
 };
 var versions = getVersions();
 

--- a/package.json
+++ b/package.json
@@ -8,10 +8,13 @@
     "url": "git://github.com/mapnik/mapnik-reference.git"
   },
   "scripts": {
-      "test": "mocha -R spec --timeout 50000"
+    "test": "mocha -R spec --timeout 50000"
   },
   "devDependencies": {
     "mocha": "1.x",
-    "glob":"4.x"
+    "glob": "4.x"
+  },
+  "dependencies": {
+    "semver": "^5.0.3"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -43,3 +43,59 @@ describe('versions', function() {
 });
 
 
+
+describe('load', function() {
+    it('should load requested version if exists', function() {
+        var spec = mapnikref.load('2.0.2');
+        assert.equal(spec.version, '2.0.2');
+    });
+
+    it('should load closer patch version if requested patch does not exist', function() {
+        var spec = mapnikref.load('2.0.12');
+        assert.equal(spec.version, '2.0.2');
+    });
+
+    it('should support x as patch', function() {
+        var spec = mapnikref.load('2.0.x');
+        assert.equal(spec.version, '2.0.2');
+    });
+
+    it('should support x as minor', function() {
+        var spec = mapnikref.load('2.x.x');
+        assert.equal(spec.version, '2.3.0');
+    });
+
+    it('should support missing patch', function() {
+        var spec = mapnikref.load('2.3');
+        assert.equal(spec.version, '2.3.0');
+    });
+
+    it('should support major only', function() {
+        var spec = mapnikref.load('2');
+        assert.equal(spec.version, '2.3.0');
+    });
+
+    it('should support range', function() {
+        var spec = mapnikref.load('2.x < 3');
+        assert.equal(spec.version, '2.3.0');
+    });
+
+    it('should support *', function() {
+        var spec = mapnikref.load('*');
+        assert.equal(spec.version, mapnikref.latest);
+    });
+
+    it('should throw if requested minor does not exist', function() {
+        assert.throws(function () {
+            mapnikref.load('2.12.0');
+        }, /Unknown mapnik-reference version/);
+    });
+
+    it('should throw for invalid version', function() {
+        assert.throws(function () {
+            mapnikref.load('invalid');
+        }, /Unknown mapnik-reference version/);
+    });
+});
+
+


### PR DESCRIPTION
Fix #108

This also:
- dynamically builds the available versions by listing
  the versions directories.
- introduces module.latest, that point to the latest version
  id available

Using "semver" module, this will also allow much advanced loading
syntax (like ranges, carret, star or x…).

@flippmoke up for a review? :)
