### PR TITLE
Make index.js browser-compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,4 @@
-var fs = require('fs'),
-    path = require('path'),
-    existsSync = require('fs').existsSync || require('path').existsSync;
+var path = require('path');
 
 var versions = [
  '2.0.0',
@@ -18,6 +16,15 @@ var versions = [
  '3.0.7'
 ];
 
+// These older versions don't have the datasource info
+var no_datasources = [
+  '2.0.0',
+  '2.0.1',
+  '2.0.2',
+  '2.1.0',
+  '2.1.1',
+  '2.2.0'
+]
 module.exports.versions = versions;
 
 module.exports.load = function(version) {
@@ -25,9 +32,8 @@ module.exports.load = function(version) {
 	throw new Error("Unknown mapnik-reference version: '" + version + "'");
     }
     var ref = require(path.join(__dirname, version, 'reference.json'));
-    var ds_path = path.join(__dirname, version, 'datasources.json');
-    if (existsSync(ds_path)) {
-	ref.datasources = require(ds_path).datasources;
+    if (no_datasources.indexOf(version) <= -1) {
+        ref.datasources = require(path.join(__dirname, version, 'datasources.json')).datasources;
     }
     return ref;
 }


### PR DESCRIPTION
This means hard-coding a list of old versions which don't have datasources.json.

Replaces #89
