### PR TITLE
add generated index.js to version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 npm-debug.log
-index.js

--- a/contributing.md
+++ b/contributing.md
@@ -2,6 +2,12 @@
 
 We welcome contributions. Please provide pull requests and notify @springmeyer for review.
 
+### Changing index.js
+
+Do not change index.js directly as it is generated. Modify index._ instead and run
+`node generate.js` instead. If the node binary is differently named on your operating
+system (e.g. nodejs) use that instead.
+
 ### Releasing
 
 1) Create a milestone for the upcoming release
@@ -50,4 +56,3 @@ NOTE: make sure your git checkout is clean first: `git status` should show no ch
 ```bash
 npm publish
 ```
-

--- a/index.js
+++ b/index.js
@@ -8,24 +8,26 @@ var semver = require('semver');
 
 
 var versions = [
-<% _.forEach(versions, function (value, key) {
-        print("    '" + value + "'");
-        if (key < versions.length - 1) {
-            print(",\n");
-        }
-    });
-%>
+    '2.0.0',
+    '2.0.1',
+    '2.0.2',
+    '2.1.0',
+    '2.1.1',
+    '2.2.0',
+    '2.3.0',
+    '3.0.0',
+    '3.0.3',
+    '3.0.6'
 ];
 
 // These older versions don't have the datasource info
 var no_datasources = [
-<% _.forEach(no_datasources, function (value, key) {
-        print("    '" + value + "'");
-        if (key < no_datasources.length - 1) {
-            print(",\n");
-        }
-    });
-%>
+    '2.0.0',
+    '2.0.1',
+    '2.0.2',
+    '2.1.0',
+    '2.1.1',
+    '2.2.0'
 ];
 module.exports.versions = versions;
 module.exports.latest = versions[versions.length - 1];
@@ -46,24 +48,46 @@ var getSatisfyingVersion = function (wanted) {
 
 var loadBrowser = function (version) {
     var versionRefs = {
-<% _.forEach(versions, function (value, key) {
-        print("       '" + value + "': {\n");
-        print("            'ref': require('./" + value + "/reference.json'),\n");
-        print("            'datasources': ");
-        if (_.some(no_datasources, function (ds) { return value === ds; })) {
-            print("null\n");
+       '2.0.0': {
+            'ref': require('./2.0.0/reference.json'),
+            'datasources': null
+        },
+       '2.0.1': {
+            'ref': require('./2.0.1/reference.json'),
+            'datasources': null
+        },
+       '2.0.2': {
+            'ref': require('./2.0.2/reference.json'),
+            'datasources': null
+        },
+       '2.1.0': {
+            'ref': require('./2.1.0/reference.json'),
+            'datasources': null
+        },
+       '2.1.1': {
+            'ref': require('./2.1.1/reference.json'),
+            'datasources': null
+        },
+       '2.2.0': {
+            'ref': require('./2.2.0/reference.json'),
+            'datasources': null
+        },
+       '2.3.0': {
+            'ref': require('./2.3.0/reference.json'),
+            'datasources': require('./2.3.0/datasources.json').datasources
+        },
+       '3.0.0': {
+            'ref': require('./3.0.0/reference.json'),
+            'datasources': require('./3.0.0/datasources.json').datasources
+        },
+       '3.0.3': {
+            'ref': require('./3.0.3/reference.json'),
+            'datasources': require('./3.0.3/datasources.json').datasources
+        },
+       '3.0.6': {
+            'ref': require('./3.0.6/reference.json'),
+            'datasources': require('./3.0.6/datasources.json').datasources
         }
-        else {
-            print("require('./" + value + "/datasources.json').datasources\n");
-        }
-        if (key < versions.length - 1) {
-            print("        },\n");
-        }
-        else {
-            print("        }");
-        }
-    });
-%>
     };
 
     var ref = versionRefs[version].ref;

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
     "url": "git://github.com/mapnik/mapnik-reference.git"
   },
   "scripts": {
-    "test": "mocha -R spec --timeout 50000",
-    "prepublish": "node generate.js",
-    "postinstall": "node generate.js"
+    "test": "mocha -R spec --timeout 50000"
   },
   "devDependencies": {
     "glob": "4.x",


### PR DESCRIPTION
Fixes #133 

Since the problems with generating index.js on npm publish and/or npm install get worse and worse I think we do not have any other choice but to re-add the generated index.js to version control.

Everytime index.js has to be changed, index._ has to be changed instead and index.js has to be generated by running `node generate.js`.