### PR TITLE
allow rule that works on the whole symbolizer

### DIFF
--- a/2.2.0/reference.json
+++ b/2.2.0/reference.json
@@ -319,6 +319,14 @@
             }
         },
         "polygon": {
+            "default": {
+                "css": "polygon",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "fill": {
                 "css": "polygon-fill",
                 "type": "color",
@@ -444,6 +452,14 @@
             }
         },
         "line": {
+            "default": {
+                "css": "line",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "stroke": {
                 "css": "line-color",
                 "default-value": "rgba(0,0,0,1)",
@@ -632,6 +648,14 @@
             }
         },
         "markers": {
+            "default": {
+                "css": "marker",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "marker-file",
                 "doc": "An SVG file that this marker shows at each placement. If no file is given, the marker will show an ellipse.",
@@ -837,6 +861,13 @@
             }
         },
         "shield": {
+            "default": {
+                "css": "shield",
+                "type": [
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "name": {
                 "css": "shield-name",
                 "type": "string",
@@ -1125,6 +1156,14 @@
             }
         },
         "line-pattern": {
+            "default": {
+                "css": "line-pattern",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "line-pattern-file",
                 "type": "uri",
@@ -1222,6 +1261,14 @@
             }
         },
         "polygon-pattern": {
+            "default": {
+                "css": "polygon-pattern",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "polygon-pattern-file",
                 "type": "uri",
@@ -1343,6 +1390,14 @@
             }
         },
         "raster": {
+            "default": {
+                "css": "raster",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "opacity": {
                 "css": "raster-opacity",
                 "default-value": 1,
@@ -1467,6 +1522,14 @@
             }
         },
         "point": {
+            "default": {
+                "css": "point",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "point-file",
                 "type": "uri",
@@ -1562,6 +1625,13 @@
             }
         },
         "text": {
+            "default": {
+                "css": "text",
+                "type": [
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "name": {
                 "css": "text-name",
                 "type": "string",
@@ -1848,6 +1918,14 @@
             }
         },
         "building": {
+            "default": {
+                "css": "building",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "fill": {
                 "css": "building-fill",
                 "default-value": "#FFFFFF",

--- a/2.3.0/reference.json
+++ b/2.3.0/reference.json
@@ -390,6 +390,14 @@
             }
         },
         "polygon": {
+            "default": {
+                "css": "polygon",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "fill": {
                 "css": "polygon-fill",
                 "type": "color",
@@ -515,6 +523,14 @@
             }
         },
         "line": {
+            "default": {
+                "css": "line",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "stroke": {
                 "css": "line-color",
                 "default-value": "rgba(0,0,0,1)",
@@ -703,6 +719,14 @@
             }
         },
         "markers": {
+            "default": {
+                "css": "marker",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "marker-file",
                 "doc": "A file that this marker shows at each placement. If no file is given, the marker will show an ellipse. Accepted formats: SVG, JPG, PNG.",
@@ -908,6 +932,13 @@
             }
         },
         "shield": {
+            "default": {
+                "css": "shield",
+                "type": [
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "name": {
                 "css": "shield-name",
                 "type": "string",
@@ -1206,6 +1237,14 @@
             }
         },
         "line-pattern": {
+            "default": {
+                "css": "line-pattern",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "line-pattern-file",
                 "type": "uri",
@@ -1310,6 +1349,14 @@
             }
         },
         "polygon-pattern": {
+            "default": {
+                "css": "polygon-pattern",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "polygon-pattern-file",
                 "type": "uri",
@@ -1431,6 +1478,14 @@
             }
         },
         "raster": {
+            "default": {
+                "css": "raster",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "opacity": {
                 "css": "raster-opacity",
                 "default-value": 1,
@@ -1554,6 +1609,14 @@
             }
         },
         "point": {
+            "default": {
+                "css": "point",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "point-file",
                 "type": "uri",
@@ -1649,6 +1712,13 @@
             }
         },
         "text": {
+            "default": {
+                "css": "text",
+                "type": [
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "name": {
                 "css": "text-name",
                 "type": "string",
@@ -1936,6 +2006,14 @@
             }
         },
         "building": {
+            "default": {
+                "css": "building",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "fill": {
                 "css": "building-fill",
                 "default-value": "#FFFFFF",

--- a/3.0.0/reference.json
+++ b/3.0.0/reference.json
@@ -407,6 +407,14 @@
             }
         },
         "polygon": {
+            "default": {
+                "css": "polygon",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "fill": {
                 "css": "polygon-fill",
                 "type": "color",
@@ -545,6 +553,14 @@
             }
         },
         "line": {
+            "default": {
+                "css": "line",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "stroke": {
                 "css": "line-color",
                 "default-value": "black",
@@ -760,6 +776,14 @@
             }
         },
         "markers": {
+            "default": {
+                "css": "marker",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "marker-file",
                 "doc": "A file that this marker shows at each placement. If no file is given, the marker will show an ellipse. Accepted formats: svg, jpg, png, tiff, and webp.",
@@ -1050,6 +1074,13 @@
             }
         },
         "shield": {
+            "default": {
+                "css": "shield",
+                "type": [
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "name": {
                 "css": "shield-name",
                 "type": "string",
@@ -1533,6 +1564,14 @@
             }
         },
         "line-pattern": {
+            "default": {
+                "css": "line-pattern",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "line-pattern-file",
                 "type": "uri",
@@ -1672,6 +1711,14 @@
             }
         },
         "polygon-pattern": {
+            "default": {
+                "css": "polygon-pattern",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "polygon-pattern-file",
                 "type": "uri",
@@ -1823,6 +1870,14 @@
             }
         },
         "raster": {
+            "default": {
+                "css": "raster",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "opacity": {
                 "css": "raster-opacity",
                 "default-value": 1.0,
@@ -1951,6 +2006,14 @@
             }
         },
         "point": {
+            "default": {
+                "css": "point",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "point-file",
                 "type": "uri",
@@ -2058,6 +2121,13 @@
             }
         },
         "text": {
+            "default": {
+                "css": "text",
+                "type": [
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "name": {
                 "css": "text-name",
                 "type": "string",
@@ -2567,6 +2637,14 @@
             }
         },
         "building": {
+            "default": {
+                "css": "building",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "fill": {
                 "css": "building-fill",
                 "expression":true,
@@ -2606,6 +2684,14 @@
             }
         },
         "dot": {
+            "default": {
+                "css": "dot",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "fill": {
                 "css": "dot-fill",
                 "default-value": "gray",

--- a/3.0.3/reference.json
+++ b/3.0.3/reference.json
@@ -419,6 +419,14 @@
             }
         },
         "polygon": {
+            "default": {
+                "css": "polygon",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "fill": {
                 "css": "polygon-fill",
                 "type": "color",
@@ -557,6 +565,14 @@
             }
         },
         "line": {
+            "default": {
+                "css": "line",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "stroke": {
                 "css": "line-color",
                 "default-value": "black",
@@ -772,6 +788,14 @@
             }
         },
         "markers": {
+            "default": {
+                "css": "marker",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "marker-file",
                 "doc": "A file that this marker shows at each placement. If no file is given, the marker will show an ellipse. Accepted formats: svg, jpg, png, tiff, and webp.",
@@ -1062,6 +1086,13 @@
             }
         },
         "shield": {
+            "default": {
+                "css": "shield",
+                "type": [
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "name": {
                 "css": "shield-name",
                 "type": "string",
@@ -1545,6 +1576,14 @@
             }
         },
         "line-pattern": {
+            "default": {
+                "css": "line-pattern",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "line-pattern-file",
                 "type": "uri",
@@ -1684,6 +1723,14 @@
             }
         },
         "polygon-pattern": {
+            "default": {
+                "css": "polygon-pattern",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "polygon-pattern-file",
                 "type": "uri",
@@ -1835,6 +1882,14 @@
             }
         },
         "raster": {
+            "default": {
+                "css": "raster",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "opacity": {
                 "css": "raster-opacity",
                 "default-value": 1.0,
@@ -1963,6 +2018,14 @@
             }
         },
         "point": {
+            "default": {
+                "css": "point",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "point-file",
                 "type": "uri",
@@ -2070,6 +2133,13 @@
             }
         },
         "text": {
+            "default": {
+                "css": "text",
+                "type": [
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "name": {
                 "css": "text-name",
                 "type": "string",
@@ -2579,6 +2649,14 @@
             }
         },
         "building": {
+            "default": {
+                "css": "building",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "fill": {
                 "css": "building-fill",
                 "expression":true,
@@ -2618,6 +2696,14 @@
             }
         },
         "dot": {
+            "default": {
+                "css": "dot",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "fill": {
                 "css": "dot-fill",
                 "default-value": "gray",

--- a/3.0.6/reference.json
+++ b/3.0.6/reference.json
@@ -419,6 +419,14 @@
             }
         },
         "polygon": {
+            "default": {
+                "css": "polygon",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "fill": {
                 "css": "polygon-fill",
                 "type": "color",
@@ -557,6 +565,14 @@
             }
         },
         "line": {
+            "default": {
+                "css": "line",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "stroke": {
                 "css": "line-color",
                 "default-value": "black",
@@ -772,6 +788,14 @@
             }
         },
         "markers": {
+            "default": {
+                "css": "marker",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "marker-file",
                 "doc": "A file that this marker shows at each placement. If no file is given, the marker will show an ellipse. Accepted formats: svg, jpg, png, tiff, and webp.",
@@ -1062,6 +1086,13 @@
             }
         },
         "shield": {
+            "default": {
+                "css": "shield",
+                "type": [
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "name": {
                 "css": "shield-name",
                 "type": "string",
@@ -1545,6 +1576,14 @@
             }
         },
         "line-pattern": {
+            "default": {
+                "css": "line-pattern",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "line-pattern-file",
                 "type": "uri",
@@ -1684,6 +1723,14 @@
             }
         },
         "polygon-pattern": {
+            "default": {
+                "css": "polygon-pattern",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "polygon-pattern-file",
                 "type": "uri",
@@ -1835,6 +1882,14 @@
             }
         },
         "raster": {
+            "default": {
+                "css": "raster",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "opacity": {
                 "css": "raster-opacity",
                 "default-value": 1.0,
@@ -1963,6 +2018,14 @@
             }
         },
         "point": {
+            "default": {
+                "css": "point",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "file": {
                 "css": "point-file",
                 "type": "uri",
@@ -2070,6 +2133,13 @@
             }
         },
         "text": {
+            "default": {
+                "css": "text",
+                "type": [
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "name": {
                 "css": "text-name",
                 "type": "string",
@@ -2579,6 +2649,14 @@
             }
         },
         "building": {
+            "default": {
+                "css": "building",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "fill": {
                 "css": "building-fill",
                 "expression":true,
@@ -2618,6 +2696,14 @@
             }
         },
         "dot": {
+            "default": {
+                "css": "dot",
+                "type": [
+                    "auto",
+                    "none"
+                ],
+                "status": "unstable"
+            },
             "fill": {
                 "css": "dot-fill",
                 "default-value": "gray",


### PR DESCRIPTION
This is a prerequisite for supporting https://github.com/mapbox/carto/issues/18 and https://github.com/mapbox/carto/issues/462 in CartoCSS. It allows a rule that works on the whole symbolizer and either suppresses it (none) or renders it with default values (auto).

Shield and text symbolizer only support none, because they don't have default values for all attributes. The cut at 2.2.0 is arbitrary. I was just lazy and thought older versions are not really relevant any more. I marked the entries as unstable to be on the safe side.