### PR TITLE
remove 'auto' option from line-pattern and polygon-pattern

### DIFF
--- a/2.2.0/reference.json
+++ b/2.2.0/reference.json
@@ -1073,7 +1073,6 @@
             "default": {
                 "css": "line-pattern",
                 "type": [
-                    "auto",
                     "none"
                 ],
                 "doc": "Allows omitting a line pattern symbolizer rule or emitting it with default values.",
@@ -1179,7 +1178,6 @@
             "default": {
                 "css": "polygon-pattern",
                 "type": [
-                    "auto",
                     "none"
                 ],
                 "doc": "Allows omitting a polygon pattern symbolizer rule or emitting it with default values.",

--- a/2.3.0/reference.json
+++ b/2.3.0/reference.json
@@ -1143,7 +1143,6 @@
             "default": {
                 "css": "line-pattern",
                 "type": [
-                    "auto",
                     "none"
                 ],
                 "doc": "Allows omitting a line pattern symbolizer rule or emitting it with default values.",
@@ -1256,7 +1255,6 @@
             "default": {
                 "css": "polygon-pattern",
                 "type": [
-                    "auto",
                     "none"
                 ],
                 "doc": "Allows omitting a polygon pattern symbolizer rule or emitting it with default values.",

--- a/3.0.0/reference.json
+++ b/3.0.0/reference.json
@@ -1466,7 +1466,6 @@
             "default": {
                 "css": "line-pattern",
                 "type": [
-                    "auto",
                     "none"
                 ],
                 "doc": "Allows omitting a line pattern symbolizer rule or emitting it with default values.",
@@ -1614,7 +1613,6 @@
             "default": {
                 "css": "polygon-pattern",
                 "type": [
-                    "auto",
                     "none"
                 ],
                 "doc": "Allows omitting a polygon pattern symbolizer rule or emitting it with default values.",

--- a/3.0.3/reference.json
+++ b/3.0.3/reference.json
@@ -1472,7 +1472,6 @@
             "default": {
                 "css": "line-pattern",
                 "type": [
-                    "auto",
                     "none"
                 ],
                 "doc": "Allows omitting a line pattern symbolizer rule.",
@@ -1620,7 +1619,6 @@
             "default": {
                 "css": "polygon-pattern",
                 "type": [
-                    "auto",
                     "none"
                 ],
                 "doc": "Allows omitting a polygon pattern symbolizer rule or emitting it with default values.",

--- a/3.0.6/reference.json
+++ b/3.0.6/reference.json
@@ -1472,7 +1472,6 @@
             "default": {
                 "css": "line-pattern",
                 "type": [
-                    "auto",
                     "none"
                 ],
                 "doc": "Allows omitting a line pattern symbolizer rule or emitting it with default values.",
@@ -1620,7 +1619,6 @@
             "default": {
                 "css": "polygon-pattern",
                 "type": [
-                    "auto",
                     "none"
                 ],
                 "doc": "Allows omitting a polygon pattern symbolizer rule or emitting it with default values.",


### PR DESCRIPTION
since they have a required property.

This is a follow-up to #139 where I overlooked that.