### PR TITLE
Default value for polygon-fill fix

### DIFF
--- a/3.0.6/reference.json
+++ b/3.0.6/reference.json
@@ -2157,7 +2157,6 @@
                 "css": "text-opacity",
                 "doc": "A number from 0 to 1 specifying the opacity for the text.",
                 "default-value": 1.0,
-                "default-meaning": "Fully opaque",
                 "expression":true,
                 "default-meaning": "Fully opaque.",
                 "type": "float"

--- a/3.0.6/reference.json
+++ b/3.0.6/reference.json
@@ -321,7 +321,7 @@
                 "css": "polygon-fill",
                 "type": "color",
                 "expression":true,
-                "default-value": "The color gray will be used for fill.",
+                "default-value": "rgba(128,128,128,1)",
                 "default-meaning": "Gray and fully opaque (alpha = 1), same as rgb(128,128,128) or rgba(128,128,128,1).",
                 "doc": "Fill color to assign to a polygon."
             },


### PR DESCRIPTION
This fix the default value for `polygon-fill` and removes a redundant property in `text-opacity`.