### PR TITLE
Deprecate shield-min-distance

### DIFF
--- a/3.0.0/reference.json
+++ b/3.0.0/reference.json
@@ -1087,7 +1087,8 @@
                 "expression":true,
                 "default-value": 0.0,
                 "default-meaning": "Shields with the same text will be rendered without restriction.",
-                "doc": "Minimum distance to the next shield with the same text. Only works for line placement."
+                "doc": "Minimum distance to any other collision object. Deprecated: replaced by `text-margin`.",
+                "status": "deprecated"
             },
             "spacing": {
                 "css": "shield-spacing",

--- a/3.0.20/reference.json
+++ b/3.0.20/reference.json
@@ -1093,7 +1093,8 @@
                 "expression":true,
                 "default-value": 0.0,
                 "default-meaning": "Shields with the same text will be rendered without restriction.",
-                "doc": "Minimum distance to the next shield with the same text. Only works for line placement."
+                "doc": "Minimum distance to any other collision object. Deprecated: replaced by `text-margin`.",
+                "status": "deprecated"
             },
             "spacing": {
                 "css": "shield-spacing",

--- a/3.0.3/reference.json
+++ b/3.0.3/reference.json
@@ -1093,7 +1093,8 @@
                 "expression":true,
                 "default-value": 0.0,
                 "default-meaning": "Shields with the same text will be rendered without restriction.",
-                "doc": "Minimum distance to the next shield with the same text. Only works for line placement."
+                "doc": "Minimum distance to any other collision object. Deprecated: replaced by `text-margin`.",
+                "status": "deprecated"
             },
             "spacing": {
                 "css": "shield-spacing",

--- a/3.0.6/reference.json
+++ b/3.0.6/reference.json
@@ -1093,7 +1093,8 @@
                 "expression":true,
                 "default-value": 0.0,
                 "default-meaning": "Shields with the same text will be rendered without restriction.",
-                "doc": "Minimum distance to the next shield with the same text. Only works for line placement."
+                "doc": "Minimum distance to any other collision object. Deprecated: replaced by `text-margin`.",
+                "status": "deprecated"
             },
             "spacing": {
                 "css": "shield-spacing",


### PR DESCRIPTION
Deprecate `shield-min-distance` as `text-min-distance` has been already deprecated in Mapnik 3 and both are replaced by `repeat-distance` and `margin`.