### PR TITLE
Prepare for newer semver versions, bring index._ and index.js in sync

### DIFF
--- a/index._
+++ b/index._
@@ -34,7 +34,7 @@ var getSatisfyingVersion = function (wanted) {
     var version = semver.maxSatisfying(versions, wanted), parsed;
     if (!version) {
         try {
-            parsed = semver(wanted);
+            parsed = semver.parse(wanted);
             parsed.patch = 'x';
             version = semver.maxSatisfying(versions, parsed.format());
         } catch (err) {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var versions = [
     '3.0.3',
     '3.0.6',
     '3.0.20',
-    '3.0.22',
+    '3.0.22'
 ];
 
 // These older versions don't have the datasource info
@@ -89,6 +89,14 @@ var loadBrowser = function (version) {
        '3.0.6': {
             'ref': require('./3.0.6/reference.json'),
             'datasources': require('./3.0.6/datasources.json').datasources
+        },
+       '3.0.20': {
+            'ref': require('./3.0.20/reference.json'),
+            'datasources': require('./3.0.20/datasources.json').datasources
+        },
+       '3.0.22': {
+            'ref': require('./3.0.22/reference.json'),
+            'datasources': require('./3.0.22/datasources.json').datasources
         }
     };
 

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ var getSatisfyingVersion = function (wanted) {
     var version = semver.maxSatisfying(versions, wanted), parsed;
     if (!version) {
         try {
-            parsed = semver(wanted);
+            parsed = semver.parse(wanted);
             parsed.patch = 'x';
             version = semver.maxSatisfying(versions, parsed.format());
         } catch (err) {


### PR DESCRIPTION
I noticed that newer versions (>= v7.0.0) of `semver` have dropped support for calling it as `semver(<version>)` while version `^5.1.0`, that is currently referenced in `package.json`, seems to support `semver.parse(<version>)` already, and that `index.js` is not in sync with `index._` anymore. This pull request should fix these two issues.