### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The structure of `reference.json` is:
 * `style`: properties of the `Style` XML element
 * `layer`: properties of the `Layer` XML element
 * `symbolizers/*`: properties that apply to **all** symbolizers
-* `symbolizers/symbolizer`: properties that apply to **each** type of symbolizer
+* `symbolizers/`_\<symbolizer\>_: properties that are specific to a given symbolizer
 * `colors`: named colors supported by Mapnik. see `include/mapnik/css_color_grammar.hpp`
 
 ### Property stability

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 It is useful for building parsers, tests, compilers, and syntax highlighting/checking for languages.
 
-[![Build Status](https://travis-ci.org/mapnik/mapnik-reference.svg)](https://travis-ci.org/mapnik/mapnik-reference)
-
-Default branch is `gh-pages` which is displayed at http://mapnik.org/mapnik-reference
+Default branch is `gh-pages`, which is displayed at http://mapnik.org/mapnik-reference
 
 ## Versioning
 
@@ -25,7 +23,7 @@ The structure of `reference.json` is:
 * `version`: the version of Mapnik targeted. Same as the containing directory.
 * `style`: properties of the `Style` XML element
 * `layer`: properties of the `Layer` XML element
-* `symbolizers/*`: properties that apply to **all** symbolizers
+* `symbolizers`: properties that apply to all symbolizers (removed from version 2.1.0 onwards)
 * `symbolizers/`_\<symbolizer\>_: properties that are specific to a given symbolizer
 * `colors`: named colors supported by Mapnik. see `include/mapnik/css_color_grammar.hpp`
 
@@ -84,4 +82,4 @@ Tests require python and node.js:
 ## Users
 
 * [carto.js](https://github.com/cartocss/carto)
-* Mapnik itself (the utility [mapnik-reference-validate.py](https://gist.github.com/springmeyer/3410845) can be used to check binding consistency like in [#1427](https://github.com/mapnik/mapnik/issues/1427))
+* [Mapnik documentation](http://mapnik.org/mapnik-reference)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and the next targeted release of Mapnik.
 
 ## Meaning
 
-The structure of the file is as such:
+The structure of `reference.json` is:
 
 * `version`: the version of Mapnik targeted. Same as the containing directory.
 * `style`: properties of the `Style` XML element
@@ -38,6 +38,7 @@ then the `status` is `stable`. Possible values are:
 - **deprecated:** `property` should not be used and will be removed in upcoming major version of Mapnik
 - **experimental:** `property` should not be used and may change, be re-named, or disappear at any time
 
+`datasources.json` separately details the properties of the possible data sources (since version 2.3.0). 
 
 ## Using
 
@@ -82,5 +83,5 @@ Tests require python and node.js:
 
 ## Users
 
-* [carto.js](https://github.com/mapbox/carto)
-* Mapnik itself (the util/validate-mapnik-instance.py is used to check binding consistency like in [#1427](https://github.com/mapnik/mapnik/issues/1427))
+* [carto.js](https://github.com/cartocss/carto)
+* Mapnik itself (the utility [mapnik-reference-validate.py](https://gist.github.com/springmeyer/3410845) can be used to check binding consistency like in [#1427](https://github.com/mapnik/mapnik/issues/1427))


### PR DESCRIPTION
Tweaks to README to update links, refer explicitly to `datasources.json` and clarify meaning.

Minor remaining queries
- There's a broken link involving travis. No longer used for CI?
- `symbolizers/*` (properties that apply to all symbolizers) doesn't seem to be used in practice. The `/*` is confusing. Should this be simply `symbolizers` ?
- ~~If `mapnik-reference-validate.py` is being recommended, perhaps it should be brought into the repository?~~ It is there, under `scripts`, but doesn't work with mapnik 3/4. Delete reference for now?
