### PR TITLE
Mapnik v3.1.0 extend

### DIFF
--- a/3.1.0/reference.json
+++ b/3.1.0/reference.json
@@ -2701,6 +2701,14 @@
                 "doc": "In case of `line` placement, offsets a text position a number of pixels parallel to its actual path. In case of `grid` placement, reduces or expands the polygon area. Positive values move the line left or expand the polygon, negative values move it right or shrink the polygon (relative to the directionality of the line or polygon winding).",
                 "status": "unstable"
             }
+            "extend": {
+                "css": "text-extend",
+                "type": "float",
+                "expression": true,
+                "default-value": 0.0,
+                "default-meaning": "",
+                "doc": "A temporary path will created that extends both the starting and final segments of a line by the given distance (starting and final segments are the same for lines with a single segment). The text will be rendered on this extended line, i.e. text will extend beyond the line length. Option is only valid with placement-line."
+            },
         },
         "building": {
             "default": {

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The structure of `reference.json` is:
 * `style`: properties of the `Style` XML element
 * `layer`: properties of the `Layer` XML element
 * `symbolizers/*`: properties that apply to **all** symbolizers
-* `symbolizers/symbolizer`: properties that apply to **each** type of symbolizer
+* `symbolizers/`_\<symbolizer\>_: properties that are specific to a given symbolizer
 * `colors`: named colors supported by Mapnik. see `include/mapnik/css_color_grammar.hpp`
 
 ### Property stability

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 It is useful for building parsers, tests, compilers, and syntax highlighting/checking for languages.
 
-[![Build Status](https://travis-ci.org/mapnik/mapnik-reference.svg)](https://travis-ci.org/mapnik/mapnik-reference)
-
-Default branch is `gh-pages` which is displayed at http://mapnik.org/mapnik-reference
+Default branch is `gh-pages`, which is displayed at http://mapnik.org/mapnik-reference
 
 ## Versioning
 
@@ -25,7 +23,7 @@ The structure of `reference.json` is:
 * `version`: the version of Mapnik targeted. Same as the containing directory.
 * `style`: properties of the `Style` XML element
 * `layer`: properties of the `Layer` XML element
-* `symbolizers/*`: properties that apply to **all** symbolizers
+* `symbolizers`: properties that apply to all symbolizers (removed from version 2.1.0 onwards)
 * `symbolizers/`_\<symbolizer\>_: properties that are specific to a given symbolizer
 * `colors`: named colors supported by Mapnik. see `include/mapnik/css_color_grammar.hpp`
 
@@ -84,4 +82,4 @@ Tests require python and node.js:
 ## Users
 
 * [carto.js](https://github.com/cartocss/carto)
-* Mapnik itself (the utility [mapnik-reference-validate.py](https://gist.github.com/springmeyer/3410845) can be used to check binding consistency like in [#1427](https://github.com/mapnik/mapnik/issues/1427))
+* [Mapnik documentation](http://mapnik.org/mapnik-reference)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and the next targeted release of Mapnik.
 
 ## Meaning
 
-The structure of the file is as such:
+The structure of `reference.json` is:
 
 * `version`: the version of Mapnik targeted. Same as the containing directory.
 * `style`: properties of the `Style` XML element
@@ -38,6 +38,7 @@ then the `status` is `stable`. Possible values are:
 - **deprecated:** `property` should not be used and will be removed in upcoming major version of Mapnik
 - **experimental:** `property` should not be used and may change, be re-named, or disappear at any time
 
+`datasources.json` separately details the properties of the possible data sources (since version 2.3.0). 
 
 ## Using
 
@@ -82,5 +83,5 @@ Tests require python and node.js:
 
 ## Users
 
-* [carto.js](https://github.com/mapbox/carto)
-* Mapnik itself (the util/validate-mapnik-instance.py is used to check binding consistency like in [#1427](https://github.com/mapnik/mapnik/issues/1427))
+* [carto.js](https://github.com/cartocss/carto)
+* Mapnik itself (the utility [mapnik-reference-validate.py](https://gist.github.com/springmeyer/3410845) can be used to check binding consistency like in [#1427](https://github.com/mapnik/mapnik/issues/1427))


### PR DESCRIPTION
A draft attempt to document PR [#3512](https://github.com/mapnik/mapnik/pull/3512).

Queries:
- ~~`expressions: true` needs checking. I didn't know how to determine from the code whether expressions would be supported.~~ Noted below that all simple key/values expected to support expressions.
- From what I could tell, the `extend` key is parsed in `parse_symbolizer_base`, which is used by multiple symbolizers rather than just Line. Is this correct? But presumably it only makes sense to document `extend` for the line symbolizer?

I would like to have a way to double-check that a given property is present in 3.1.0. I would have expected "extend" to be found when using `strings libmapnik.so.3.1.0`, but it drew a blank. I tried `scripts/validate_mapnik_instance.py`, but I don't think this will work unless the python bindings match 3.1.0 (which they didn't seem to).

I do think it would be helpful to retrospectively create an approximate entry in the mapnik `CHANGELOG.md` to separate out then changes up to 3.1. It looks like everything after 3.0.20 has been lumped under the 4.0.0 entry?


