### PR TITLE
V4.2.0 additions

### DIFF
--- a/4.2.0/reference.json
+++ b/4.2.0/reference.json
@@ -772,12 +772,13 @@
                     "line",
                     "interior",
                     "vertex-first",
-                    "vertex-last"
+                    "vertex-last",
+                    "angled-point"					
                 ],
                 "expression":true,
                 "default-value": "point",
                 "default-meaning": "Place markers at the center point (centroid) of the geometry.",
-                "doc": "Attempt to place markers on a point, in the center of a polygon, or if markers-placement:line, then multiple times along a line. 'interior' placement can be used to ensure that points placed on polygons are forced to be inside the polygon interior. The 'vertex-first' and 'vertex-last' options can be used to place markers at the first or last vertex of lines or polygons."
+                "doc": "'point' placement attempts to place a marker at the center point (centroid) of the geometry (i.e. halfway along line geometries). 'line' attempts multiple placements along a line. 'interior' placement ensures that a marker placed on a polygon will be inside the polygon interior. 'vertex-first' and 'vertex-last' place a marker at either the first or last vertex of lines or polygons. 'angled_point' behaves as 'point', but angles the marker to match the orientation of the (middle) segment it is placed on."
             },
             "multi-policy": {
                 "css": "marker-multi-policy",

--- a/4.2.0/reference.json
+++ b/4.2.0/reference.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.1.0",
+    "version": "4.2.0",
     "style": {
         "filter-mode": {
             "type": [

--- a/4.2.0/reference.json
+++ b/4.2.0/reference.json
@@ -922,6 +922,15 @@
                 "expression":true,
                 "default-meaning": "In the case of marker-placement:line then draw a marker every 100 pixels along a line."
             },
+            "spacing-offset": {
+                "css": "marker-spacing-offset",
+                "doc": "Offset used in `line` placement (added version 4). Markers will be offset from default starting position of half the `spacing` parameter. Note feature may be unstable on short lines, see https://github.com/mapnik/mapnik/issues/4214.",
+                "default-value": 0.0,
+                "type": "float",
+                "expression":true,
+                "default-meaning": "Markers will not be offset from normal positions with `line` placement."
+                "status": "experimental"
+            },
             "max-error": {
                 "css": "marker-max-error",
                 "type": "float",

--- a/4.2.0/reference.json
+++ b/4.2.0/reference.json
@@ -127,7 +127,7 @@
         "type":"string",
         "required" : true,
         "default-meaning": "No layer name has been provided",
-        "doc": "The name of a layer. Can be anything you wish and is not strictly validated, but ideally unique  in the map."
+        "doc": "The name of a layer. Can be anything you wish and is not strictly validated, but ideally unique in the map."
       },
       "srs": {
         "css": "srs",
@@ -215,6 +215,58 @@
             "default-meaning": "Features are not cached between rendering multiple styles. The datasource is queried for each style.",
             "doc": "Setting this to `on` triggers Mapnik to attempt to cache features in memory for rendering when (and only when) a layer has multiple styles attached to it."
         }
+      "comp-op": {
+        "css": "comp-op",
+        "default-value": "src-over",
+        "default-meaning": "add the current layer on top of other layers",
+        "doc": "Composite operation. This defines how this layer should behave relative to layers atop or below it. See https://github.com/mapnik/mapnik/pull/3474.",
+        "type": [
+          "clear",
+          "src",
+          "dst",
+          "src-over",
+          "dst-over",
+          "src-in",
+          "dst-in",
+          "src-out",
+          "dst-out",
+          "src-atop",
+          "dst-atop",
+          "xor",
+          "plus",
+          "minus",
+          "multiply",
+          "divide",
+          "screen",
+          "overlay",
+          "darken",
+          "lighten",
+          "color-dodge",
+          "color-burn",
+          "linear-dodge",
+          "linear-burn",
+          "hard-light",
+          "soft-light",
+          "difference",
+          "exclusion",
+          "contrast",
+          "invert",
+          "invert-rgb",
+          "grain-merge",
+          "grain-extract",
+          "hue",
+          "saturation",
+          "color",
+          "value"
+        ]
+      },
+      "opacity": {
+        "css": "opacity",
+        "type": "float",
+        "doc": "An alpha value for the layer, which means an alpha applied to all features in separate buffer and then composited back to the overall buffer for the current layer or nested set of layers.",
+        "default-value": 1.0,
+        "default-meaning": "No separate buffer will be used and no alpha will be applied to the layer after rendering."
+      }
     },
     "symbolizers" : {
         "map": {

--- a/4.2.0/reference.json
+++ b/4.2.0/reference.json
@@ -677,6 +677,16 @@
                 "range": "0-1",
                 "doc": "Smooths out geometry angles. 0 is no smoothing, 1 is fully smoothed. Values greater than 1 will produce wild, looping geometries."
             },
+            "smooth-algorithm": {
+                "css": "line-smooth-algorithm",
+                "type": ["basic",
+                         "adaptive"
+                        ],
+                "expression":true,
+                "default-value": "basic",
+                "default-meaning": "The geometry will be simplified using the original non-adaptive algorithm.",
+                "doc": "Set the alogorithm used to smooth geometries. `adaptive` will increase the number of interpolation points at sharper bends, leading to more realistic smoothing."
+            },
             "offset": {
                 "css": "line-offset",
                 "type": "float",

--- a/4.2.0/reference.json
+++ b/4.2.0/reference.json
@@ -759,7 +759,7 @@
                 "expression":true
             }
         },
-        "markers": {
+        "marker": {
             "default": {
                 "css": "marker",
                 "type": [

--- a/4.2.0/reference.json
+++ b/4.2.0/reference.json
@@ -2739,6 +2739,14 @@
                 "default-meaning": "Default set of typographic features recommended by OpenType specification. Ligatures are turned off by default when `character-spacing` is greater than zero.",
                 "doc": "Comma separated list of OpenType typographic features. The syntax and semantics conforms to `font-feature-settings` from W3C CSS."
             },
+            "lang": {
+                "css": "text-lang",
+                "type": "string",
+                "expression": true
+                "default-value": "",
+                "default-meaning": "No explicit shaping control of CJK characters.",
+                "doc": "Allows explicit shaping control of CJK characters by passing qualifiers such as `zh-Hant` (added version 4)."
+            },
             "largest-bbox-only": {
                 "css": "text-largest-bbox-only",
                 "type": "boolean",

--- a/4.2.0/reference.json
+++ b/4.2.0/reference.json
@@ -1411,7 +1411,7 @@
             },
             "placement-type": {
                 "css": "shield-placement-type",
-                "doc": "Re-position and/or re-size shield to avoid overlaps. \"simple\" for basic algorithm (using shield-placements string,) \"dummy\" to turn this feature off.",
+                "doc": "Re-position and/or re-size shield to avoid overlaps. \"simple\" for basic algorithm (using shield-placements string,) \"dummy\" to turn this feature off. The `list` placement type is not supported by CartoCSS.",
                 "type": [
                     "dummy",
                     "simple",
@@ -2529,7 +2529,7 @@
             },
             "placement-type": {
                 "css": "text-placement-type",
-                "doc": "Re-position and/or re-size text to avoid overlaps. \"simple\" for basic algorithm (using text-placements string,) \"dummy\" to turn this feature off.",
+                "doc": "Re-position and/or re-size text to avoid overlaps. \"simple\" for basic algorithm (using text-placements string,) \"dummy\" to turn this feature off. The `list` placement type is not supported by CartoCSS.",
                 "type": [
                     "dummy",
                     "simple",

--- a/4.2.0/reference.json
+++ b/4.2.0/reference.json
@@ -685,7 +685,7 @@
                 "expression":true,
                 "default-value": "basic",
                 "default-meaning": "The geometry will be simplified using the original non-adaptive algorithm.",
-                "doc": "Set the alogorithm used to smooth geometries. `adaptive` will increase the number of interpolation points at sharper bends, leading to more realistic smoothing."
+                "doc": "Set the alogorithm used to smooth geometries (added version 4). `adaptive` will increase the number of interpolation points at sharper bends, leading to more realistic smoothing."
             },
             "offset": {
                 "css": "line-offset",

--- a/4.2.0/reference.json
+++ b/4.2.0/reference.json
@@ -219,7 +219,7 @@
         "css": "comp-op",
         "default-value": "src-over",
         "default-meaning": "add the current layer on top of other layers",
-        "doc": "Composite operation. This defines how this layer should behave relative to layers atop or below it. See https://github.com/mapnik/mapnik/pull/3474.",
+        "doc": "Composite operation (added version 4). This defines how this layer should behave relative to layers atop or below it. See https://github.com/mapnik/mapnik/pull/3474.",
         "type": [
           "clear",
           "src",
@@ -263,7 +263,7 @@
       "opacity": {
         "css": "opacity",
         "type": "float",
-        "doc": "An alpha value for the layer, which means an alpha applied to all features in separate buffer and then composited back to the overall buffer for the current layer or nested set of layers.",
+        "doc": "An alpha value for the layer (added version 4), which means an alpha applied to all features in separate buffer and then composited back to the overall buffer for the current layer or nested set of layers.",
         "default-value": 1.0,
         "default-meaning": "No separate buffer will be used and no alpha will be applied to the layer after rendering."
       }
@@ -830,7 +830,7 @@
                 "expression":true,
                 "default-value": "point",
                 "default-meaning": "Place markers at the center point (centroid) of the geometry.",
-                "doc": "'point' placement attempts to place a marker at the center point (centroid) of the geometry (i.e. halfway along line geometries). 'line' attempts multiple placements along a line. 'interior' placement ensures that a marker placed on a polygon will be inside the polygon interior. 'vertex-first' and 'vertex-last' place a marker at either the first or last vertex of lines or polygons. 'angled_point' behaves as 'point', but angles the marker to match the orientation of the (middle) segment it is placed on."
+                "doc": "'point' placement attempts to place a marker at the center point (centroid) of the geometry (i.e. halfway along line geometries). 'line' attempts multiple placements along a line. 'interior' placement ensures that a marker placed on a polygon will be inside the polygon interior. 'vertex-first' and 'vertex-last' place a marker at either the first or last vertex of lines or polygons. 'angled_point' (added version 4) behaves as 'point', but angles the marker to match the orientation of the (middle) segment it is placed on."
             },
             "multi-policy": {
                 "css": "marker-multi-policy",

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var versions = [
     '3.0.6',
     '3.0.20',
     '3.0.22',
-    '3.1.0'
+    '4.2.0'
 ];
 
 // These older versions don't have the datasource info
@@ -99,9 +99,9 @@ var loadBrowser = function (version) {
             'ref': require('./3.0.22/reference.json'),
             'datasources': require('./3.0.22/datasources.json').datasources
         },
-       '3.1.0': {
-            'ref': require('./3.1.0/reference.json'),
-            'datasources': require('./3.1.0/datasources.json').datasources
+       '4.2.0': {
+            'ref': require('./4.2.0/reference.json'),
+            'datasources': require('./4.2.0/datasources.json').datasources
         }
     };
 


### PR DESCRIPTION
Additions relating to PRs
mapnik/mapnik#4493
mapnik/mapnik#4132 (flagged as experimental since feature may be unstable)
mapnik/mapnik#4031
mapnik/mapnik#3782
mapnik/mapnik#3474 (only comp-op documented - CartoCSS won't support the nesting component)

There were some minor queries, e.g. it wasn't clear how `angled-point` markers would work with polygons, but I think this covers 90% of the documentation and the rest can be tweaked.

There may be other PRs that change the rendering feature set that I have missed?

I haven't documented the geobuf data source (#3715).




